### PR TITLE
Fixed readme

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,7 +1,7 @@
-#GitHub Repository for my Website
+# GitHub Repository for my Website
 
 So that everybody can see, what happens when you visit my site.
 Surprise surprise, no crypto mining, no data collecting.
 
-Nothing bloated in anyway.
+Nothing bloated in anyway.\
 https://braynmerdes.com/


### PR DESCRIPTION
-Added a blank space between the pound symbol and the Headline so Markdown can recognize it as a Headline.

-Added a backslash at the end of line six. That creates the desired line break between line 6 and 7 that, without the backslash, will not be depicted correctly in markdown format